### PR TITLE
Add Cellular_Ping function and enhance AT read logging

### DIFF
--- a/source/cellular_pktio.c
+++ b/source/cellular_pktio.c
@@ -636,14 +636,7 @@ static char * _Cellular_ReadLine( CellularContext_t * pContext,
             /* Add a NULL after the bytesRead. This is required for further processing. */
             pRead[ bytesRead ] = '\0';
 
-            if (bytesRead > 50)
-            {
-                LogDebug( ( "AT Read %u bytes, data(0-%zu): %.50s", ( unsigned int ) bytesRead, 50, pRead ) );
-            }
-            else
-            {
-                LogDebug( ( "AT Read %u bytes, data(0-%zu): %s", ( unsigned int ) bytesRead, bytesRead, pRead ) );
-            }
+            LogDebug( ( "AT Read %u bytes, data[%p]", ( unsigned int ) bytesRead, pRead ) );
             /* Set the pBytesRead only when actual bytes read from comm interface. */
             *pBytesRead = bytesRead + partialDataRead;
 

--- a/source/cellular_pktio.c
+++ b/source/cellular_pktio.c
@@ -636,7 +636,14 @@ static char * _Cellular_ReadLine( CellularContext_t * pContext,
             /* Add a NULL after the bytesRead. This is required for further processing. */
             pRead[ bytesRead ] = '\0';
 
-            LogDebug( ( "AT Read %u bytes, data[%p]", ( unsigned int ) bytesRead, pRead ) );
+            if (bytesRead > 50)
+            {
+                LogDebug( ( "AT Read %u bytes, data(0-%zu): %.50s", ( unsigned int ) bytesRead, 50, pRead ) );
+            }
+            else
+            {
+                LogDebug( ( "AT Read %u bytes, data(0-%zu): %s", ( unsigned int ) bytesRead, bytesRead, pRead ) );
+            }
             /* Set the pBytesRead only when actual bytes read from comm interface. */
             *pBytesRead = bytesRead + partialDataRead;
 

--- a/source/include/cellular_api.h
+++ b/source/include/cellular_api.h
@@ -565,6 +565,22 @@ CellularError_t Cellular_GetHostByName( CellularHandle_t cellularHandle,
                                         char * pResolvedAddress );
 
 /**
+ * @brief Send a single ICMP ping and return the raw modem result code.
+ *
+ * @param[in] cellularHandle The opaque cellular context pointer created by Cellular_Init.
+ * @param[in] contextId PDP context ID to use for the ping.
+ * @param[in] pHost Null-terminated IP address string to ping (e.g. "8.8.8.8").
+ * @param[in] timeoutS Per-ping timeout in seconds passed to AT+QPING.
+ *
+ * @return 0 on success, modem error code on failure (e.g. 565, 569), or -1 if
+ *         the AT command failed or the URC was not received within timeoutS + 2 s.
+ */
+int32_t Cellular_Ping( CellularHandle_t cellularHandle,
+                       uint8_t contextId,
+                       const char * pHost,
+                       uint32_t timeoutS );
+
+/**
  * @brief Set options for a socket.
  *
  * @param[in] cellularHandle The opaque cellular context pointer created by Cellular_Init.


### PR DESCRIPTION
Adds Cellular_Ping() to cellular_api.h — synchronous ping returning the raw modem result code from AT+QPING (0 = success, 565 = routing failure, 569 = timeout, -1 = URC not received). Uses the same queue/URC pattern as Cellular_GetHostByName.

Improves _Cellular_ReadLine debug logging to show actual data content (up to 50 bytes) rather than a pointer address, making AT traces readable in serial logs.

<!--- Title -->
This pull request introduces a new API for sending ICMP pings from the modem and improves debug logging in the AT command read function. The most important changes are grouped by theme below.

### New Feature: ICMP Ping API

* Added a new function `Cellular_Ping` to `cellular_api.h`, which allows sending a single ICMP ping using the modem and returns the raw modem result code. This function provides details on parameters and return values in its documentation.

### Logging Improvements

* Enhanced debug logging in `_Cellular_ReadLine` in `cellular_pktio.c` to avoid printing excessively large data buffers. Now, if more than 50 bytes are read, only the first 50 bytes are logged, improving log readability and safety.

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
